### PR TITLE
corrected bug with indices of rows

### DIFF
--- a/fiat_toolbox/metrics_writer/fiat_write_return_period_threshold.py
+++ b/fiat_toolbox/metrics_writer/fiat_write_return_period_threshold.py
@@ -142,4 +142,4 @@ class ExceedanceProbabilityCalculator:
         result = np.full(len(df), np.nan)
         result[mask] = np.round((1 - np.exp(-T / RP[mask])) * 100, 1)
 
-        return pd.Series(result, name="Exceedance Probability")
+        return pd.Series(result, name="Exceedance Probability", index=df.index)


### PR DESCRIPTION
Found a bug where a series was created without index, but it was then merged to a dataframe with the Object ID as index, which created inconcistencies.