### PR TITLE
fix(footprints): Avoid warning on Object ID column type after aggregation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,10 @@
     "sonarlint.connectedMode.project": {
         "connectionId": "deltares",
         "projectKey": "deltares_fiat-toolbox"
-    }
+    },
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/fiat_toolbox/spatial_output/footprints.py
+++ b/fiat_toolbox/spatial_output/footprints.py
@@ -485,9 +485,12 @@ class Footprints:
             bffid_objectid_mapping.update(
                 {bffid: "_".join([str(x) for x in all_object_ids])}
             )
+        # Change column type to string
+        gdf[self.fiat_columns.object_id] = gdf[self.fiat_columns.object_id].astype(str)
         gdf.loc[
             gdf[field_name].isin(multiple_bffid), self.fiat_columns.primary_object_type
         ] = gdf[field_name].map(bffid_object_mapping)
+        
         gdf.loc[gdf[field_name].isin(multiple_bffid), self.fiat_columns.object_id] = (
             gdf[field_name].map(bffid_objectid_mapping)
         )


### PR DESCRIPTION
Aggregation was combing different Object IDs which are integers but the combination is a string. So now change type to string to avoid warnings. 